### PR TITLE
fix built in target validation logic

### DIFF
--- a/make2help.go
+++ b/make2help.go
@@ -9,9 +9,43 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const (
+	builtInTargetPhony              = ".PHONY"
+	builtInTargetSuffixes           = ".SUFFIXES"
+	builtInTargetDefault            = ".DEFAULT"
+	builtInTargetPrecious           = ".PRECIOUS"
+	builtInTargetIntermediate       = ".INTERMEDIATE"
+	builtInTargetSecondary          = ".SECONDARY"
+	builtInTargetSecondExpansion    = ".SECONDEXPANSION"
+	builtInTargetDeleteOnError      = ".DELETE_ON_ERROR"
+	builtInTargetIgnore             = ".IGNORE"
+	builtInTargetLowResolutionTime  = ".LOW_RESOLUTION_TIME"
+	builtInTargetSilent             = ".SILENT"
+	builtInTargetExportAllVariables = ".EXPORT_ALL_VARIABLES"
+	builtInTargetNotParallel        = ".NOTPARALLEL"
+	builtInTargetOneShell           = ".ONESHELL"
+	builtInTargetPosix              = ".POSIX"
+)
+
 var (
 	ruleReg          = regexp.MustCompile(`^(\S+):`)
-	builtinTargetReg = regexp.MustCompile(`^\.[A-Z_]{5,}`) // ex. ".PHONY"
+	isBuiltInTargets = map[string]bool{
+		builtInTargetPhony:              true,
+		builtInTargetSuffixes:           true,
+		builtInTargetDefault:            true,
+		builtInTargetPrecious:           true,
+		builtInTargetIntermediate:       true,
+		builtInTargetSecondary:          true,
+		builtInTargetSecondExpansion:    true,
+		builtInTargetDeleteOnError:      true,
+		builtInTargetIgnore:             true,
+		builtInTargetLowResolutionTime:  true,
+		builtInTargetSilent:             true,
+		builtInTargetExportAllVariables: true,
+		builtInTargetNotParallel:        true,
+		builtInTargetOneShell:           true,
+		builtInTargetPosix:              true,
+	}
 )
 
 func scan(filepath string) (rules, error) {
@@ -32,12 +66,10 @@ func scan(filepath string) (rules, error) {
 
 		if matches := ruleReg.FindStringSubmatch(line); len(matches) > 1 {
 			target := matches[1]
-			if target == ".PHONY" {
+			if isBuiltInTargets[target] {
 				continue
 			}
-			if !builtinTargetReg.MatchString(target) {
-				r[target] = buf
-			}
+			r[target] = buf
 		}
 		if len(buf) > 0 {
 			buf = []string{}

--- a/make2help_test.go
+++ b/make2help_test.go
@@ -17,6 +17,7 @@ func TestScan(t *testing.T) {
 		"task2": []string{},
 		"task3": []string{"task3 desu", "multi line"},
 		"task4": []string{"task4 desuyo"},
+		"task5": []string{"task5 no phony"},
 	}
 
 	if !reflect.DeepEqual(r, expect) {

--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -14,3 +14,8 @@ task1:
 .PHONY: task4
 task4:
 	@echo task4
+
+## task5 no phony
+.DEFAULT: task5
+task5:
+	@echo task5


### PR DESCRIPTION
This program had not be supported target that has `.` prefix.

So  this PR fixed it.