### PR TITLE
Support targets have whitespace suffix

### DIFF
--- a/make2help.go
+++ b/make2help.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	ruleReg          = regexp.MustCompile(`^(\S+):`)
+	ruleReg          = regexp.MustCompile(`^(\S+)\s*:`)
 	isBuiltInTargets = map[string]bool{
 		builtInTargetPhony:              true,
 		builtInTargetSuffixes:           true,

--- a/make2help_test.go
+++ b/make2help_test.go
@@ -18,6 +18,7 @@ func TestScan(t *testing.T) {
 		"task3": []string{"task3 desu", "multi line"},
 		"task4": []string{"task4 desuyo"},
 		"task5": []string{"task5 no phony"},
+		"task6": []string{"task6 suffix whitespace"},
 	}
 
 	if !reflect.DeepEqual(r, expect) {

--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -19,3 +19,7 @@ task4:
 .DEFAULT: task5
 task5:
 	@echo task5
+
+## task6 suffix whitespace
+task6 	:
+	@echo task6


### PR DESCRIPTION
Before, targets has whitespace suffix was not supported.
```
## task hoge
hoge :
	@echo task hoge
```
But, this PR is corresponding to this problem.