### PR TITLE
Eliminate pattern rules

### DIFF
--- a/make2help.go
+++ b/make2help.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	ruleReg          = regexp.MustCompile(`^(\S+):`)
+	ruleReg          = regexp.MustCompile(`^(\S+)\s*:`)
 	isBuiltInTargets = map[string]bool{
 		builtInTargetPhony:              true,
 		builtInTargetSuffixes:           true,

--- a/make2help.go
+++ b/make2help.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	ruleReg          = regexp.MustCompile(`^(\S+)\s*:`)
+	ruleReg          = regexp.MustCompile(`^([^\s%]+)\s*:`)
 	isBuiltInTargets = map[string]bool{
 		builtInTargetPhony:              true,
 		builtInTargetSuffixes:           true,

--- a/make2help_test.go
+++ b/make2help_test.go
@@ -18,6 +18,7 @@ func TestScan(t *testing.T) {
 		"task3": []string{"task3 desu", "multi line"},
 		"task4": []string{"task4 desuyo"},
 		"task5": []string{"task5 no phony"},
+		"task6": []string{"task6 suffix whitespace"},
 	}
 
 	if !reflect.DeepEqual(r, expect) {

--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -23,3 +23,7 @@ task5:
 ## task6 suffix whitespace
 task6 	:
 	@echo task6
+
+## task7 pattern rule
+task7%:
+	@echo task7

--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -19,3 +19,7 @@ task4:
 .DEFAULT: task5
 task5:
 	@echo task5
+
+## task6 suffix whitespace
+task6 	:
+	@echo task6


### PR DESCRIPTION
It is very difficult to expand pattern rules(tasks with '%' in the name) correctly.
And, In many cases they are only an intermediate target.
So, to support pattern rule documentation causes confusion.

This PR makes pattern rules implicitly undocumented.